### PR TITLE
fix: git-action: mission colon in auto release workflow

### DIFF
--- a/.github/workflows/build_upload.yml
+++ b/.github/workflows/build_upload.yml
@@ -63,7 +63,7 @@ jobs:
           echo "::set-output name=pub_method::$pub_method"
           echo "::set-output name=oss_exists::$oss_exists"
           echo "::set-output name=ftp_exists::$ftp_exists"
-          echo "::set-output name=is_tag_create:$is_tag_create"
+          echo "::set-output name=is_tag_create::$is_tag_create"
       - name: show environment
         run: |
           echo bin = ${{steps.vars.outputs.bin}}


### PR DESCRIPTION
fix: git-action: mission colon in auto release workflow