### PR TITLE
fix: The correct estimate of GasFeeCap when replacing the message

### DIFF
--- a/service/message_selector.go
+++ b/service/message_selector.go
@@ -489,7 +489,7 @@ func (w *work) estimateMessage(ctx context.Context,
 
 	for _, msg := range msgs {
 		// global msg meta
-		newMsgMeta := mergeMsgSpec(sharedParams, msg.Meta, addrInfo, msg)
+		newMsgMeta := mergeMsgSpec(sharedParams, msg.Meta, addrInfo)
 
 		if msg.GasFeeCap.NilOrZero() && !newMsgMeta.GasFeeCap.NilOrZero() {
 			msg.GasFeeCap = newMsgMeta.GasFeeCap
@@ -605,21 +605,21 @@ type GasSpec struct {
 	BaseFee           big.Int
 }
 
-func mergeMsgSpec(globalSpec *types.SharedSpec, sendSpec *types.SendSpec, addrInfo *types.Address, msg *types.Message) *GasSpec {
+func mergeMsgSpec(globalSpec *types.SharedSpec, sendSpec *types.SendSpec, addrInfo *types.Address) *GasSpec {
 	newMsgMeta := &GasSpec{
 		GasOverEstimation: sendSpec.GasOverEstimation,
 		GasOverPremium:    sendSpec.GasOverPremium,
 		MaxFee:            sendSpec.MaxFee,
 	}
 
-	if sendSpec.GasOverEstimation == 0 {
+	if newMsgMeta.GasOverEstimation == 0 {
 		if addrInfo.GasOverEstimation != 0 {
 			newMsgMeta.GasOverEstimation = addrInfo.GasOverEstimation
 		} else if globalSpec != nil {
 			newMsgMeta.GasOverEstimation = globalSpec.GasOverEstimation
 		}
 	}
-	if sendSpec.MaxFee.NilOrZero() {
+	if newMsgMeta.MaxFee.NilOrZero() {
 		if !addrInfo.MaxFee.NilOrZero() {
 			newMsgMeta.MaxFee = addrInfo.MaxFee
 		} else if globalSpec != nil {
@@ -627,20 +627,18 @@ func mergeMsgSpec(globalSpec *types.SharedSpec, sendSpec *types.SendSpec, addrIn
 		}
 	}
 
-	if msg.GasFeeCap.NilOrZero() {
-		if !addrInfo.GasFeeCap.NilOrZero() {
-			newMsgMeta.GasFeeCap = addrInfo.GasFeeCap
-		} else if globalSpec != nil {
-			newMsgMeta.GasFeeCap = globalSpec.GasFeeCap
-		}
-	}
-
-	if sendSpec.GasOverPremium == 0 {
+	if newMsgMeta.GasOverPremium == 0 {
 		if addrInfo.GasOverPremium != 0 {
 			newMsgMeta.GasOverPremium = addrInfo.GasOverPremium
 		} else if globalSpec.GasOverPremium != 0 {
 			newMsgMeta.GasOverPremium = globalSpec.GasOverPremium
 		}
+	}
+
+	if !addrInfo.GasFeeCap.NilOrZero() {
+		newMsgMeta.GasFeeCap = addrInfo.GasFeeCap
+	} else if globalSpec != nil {
+		newMsgMeta.GasFeeCap = globalSpec.GasFeeCap
 	}
 
 	if !addrInfo.BaseFee.NilOrZero() {

--- a/service/message_selector_test.go
+++ b/service/message_selector_test.go
@@ -52,15 +52,10 @@ func TestMergeMsgSpec(t *testing.T) {
 	}
 	emptyAddrInfo := &types.Address{}
 
-	msg := testhelper.NewMessage()
-	msg2 := testhelper.NewMessage()
-	msg2.GasFeeCap = testhelper.DefGasFeeCap
-
 	tests := []struct {
 		globalSpec *types.SharedSpec
 		sendSpec   *types.SendSpec
 		addrInfo   *types.Address
-		msg        *types.Message
 
 		expect *GasSpec
 	}{
@@ -68,43 +63,37 @@ func TestMergeMsgSpec(t *testing.T) {
 			globalSpec: DefSharedParams,
 			sendSpec:   emptySendSpec,
 			addrInfo:   emptyAddrInfo,
-			msg:        msg,
 			expect:     &GasSpec{GasOverEstimation: DefSharedParams.GasOverEstimation, MaxFee: DefSharedParams.MaxFee, GasOverPremium: 0, GasFeeCap: DefSharedParams.GasFeeCap, BaseFee: DefSharedParams.BaseFee},
 		},
 		{
 			defSharedParams,
 			sendSpec,
 			addrInfo,
-			msg,
 			&GasSpec{GasOverEstimation: sendSpec.GasOverEstimation, MaxFee: sendSpec.MaxFee, GasOverPremium: sendSpec.GasOverPremium, GasFeeCap: addrInfo.GasFeeCap, BaseFee: addrInfo.BaseFee},
 		},
 		{
 			defSharedParams,
 			emptySendSpec,
 			addrInfo,
-			msg,
 			&GasSpec{GasOverEstimation: addrInfo.GasOverEstimation, MaxFee: addrInfo.MaxFee, GasOverPremium: addrInfo.GasOverPremium, GasFeeCap: addrInfo.GasFeeCap, BaseFee: addrInfo.BaseFee},
 		},
 		{
 			defSharedParams,
 			emptySendSpec,
 			emptyAddrInfo,
-			msg,
 			&GasSpec{GasOverEstimation: defSharedParams.GasOverEstimation, MaxFee: defSharedParams.MaxFee, GasOverPremium: defSharedParams.GasOverPremium, GasFeeCap: defSharedParams.GasFeeCap, BaseFee: defSharedParams.BaseFee},
 		},
 		{
 			defSharedParams,
 			emptySendSpec,
 			addrInfo,
-			msg2,
-			&GasSpec{GasOverEstimation: addrInfo.GasOverEstimation, MaxFee: addrInfo.MaxFee, GasOverPremium: addrInfo.GasOverPremium, BaseFee: addrInfo.BaseFee},
+			&GasSpec{GasOverEstimation: addrInfo.GasOverEstimation, MaxFee: addrInfo.MaxFee, GasOverPremium: addrInfo.GasOverPremium, GasFeeCap: addrInfo.GasFeeCap, BaseFee: addrInfo.BaseFee},
 		},
 		{
 			defSharedParams,
 			emptySendSpec,
 			emptyAddrInfo,
-			msg2,
-			&GasSpec{GasOverEstimation: defSharedParams.GasOverEstimation, MaxFee: defSharedParams.MaxFee, GasOverPremium: defSharedParams.GasOverPremium, BaseFee: defSharedParams.BaseFee},
+			&GasSpec{GasOverEstimation: defSharedParams.GasOverEstimation, MaxFee: defSharedParams.MaxFee, GasOverPremium: defSharedParams.GasOverPremium, GasFeeCap: defSharedParams.GasFeeCap, BaseFee: defSharedParams.BaseFee},
 		},
 	}
 

--- a/service/message_selector_test.go
+++ b/service/message_selector_test.go
@@ -109,7 +109,7 @@ func TestMergeMsgSpec(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		gasSpec := mergeMsgSpec(test.globalSpec, test.sendSpec, test.addrInfo, test.msg)
+		gasSpec := mergeMsgSpec(test.globalSpec, test.sendSpec, test.addrInfo)
 		assert.Equal(t, test.expect, gasSpec)
 	}
 }
@@ -672,7 +672,7 @@ func checkGasFee(t *testing.T, srcMsgs, currMsgs *types.Message, sharedParams *t
 	if srcMsgs.Meta != nil {
 		meta = srcMsgs.Meta
 	}
-	gasSpec := mergeMsgSpec(sharedParams, meta, addrInfo, srcMsgs)
+	gasSpec := mergeMsgSpec(sharedParams, meta, addrInfo)
 	gasLimit := testhelper.DefGasUsed
 	gasPremium := testhelper.DefGasPremium
 	if gasSpec.GasOverEstimation != 0 {


### PR DESCRIPTION
## 关联的Issues (Related Issues)
<!-- 列出本 PR 尝试解决或修复的 issues，或者描述本 PR 的目的。 -->
<!-- link all issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made.-->

close filecoin-project/venus/issues#5546

## 改动 (Proposed Changes)
<!-- 改动清单 -->
<!-- provide a clear list of the changes being made-->


## 附注 (Additional Info)
<!-- 需要额外了解的信息 -->
<!-- callouts, links to documentation, and etc-->

## 自查清单 (Checklist)

在你认为本 PR 满足被审阅的标准之前，需要确保 / Before you mark the PR ready for review, please make sure that:
- [x] 符合Venus项目管理规范中关于PR的[相关标准](https://github.com/ipfs-force-community/dev-guidances/blob/master/%E9%A1%B9%E7%9B%AE%E7%AE%A1%E7%90%86/Venus/PR%E5%91%BD%E5%90%8D%E8%A7%84%E8%8C%83.md) / The PR follows the PR standards set out in the Venus project management guidelines
- [x] 具有清晰明确的[commit message](https://github.com/ipfs-force-community/dev-guidances/blob/master/%E8%B4%A8%E9%87%8F%E7%AE%A1%E7%90%86/%E4%BB%A3%E7%A0%81/git%E4%BD%BF%E7%94%A8/commit-message%E9%A3%8E%E6%A0%BC%E8%A7%84%E8%8C%83.md) / All commits have a clear commit message.
- [x] 包含相关的的[测试用例](https://github.com/ipfs-force-community/dev-guidances/blob/master/%E8%B4%A8%E9%87%8F%E7%AE%A1%E7%90%86/%E4%BB%A3%E7%A0%81/%E4%BB%A3%E7%A0%81%E5%BA%93/%E6%A3%80%E6%9F%A5%E9%A1%B9/%E5%8D%95%E5%85%83%E6%B5%8B%E8%AF%95.md)或者不需要新增测试用例 / This PR has tests for new functionality or change in behaviour or not need to add new tests.
- [x] 包含相关的的指南以及[文档](https://github.com/ipfs-force-community/dev-guidances/tree/master/%E8%B4%A8%E9%87%8F%E7%AE%A1%E7%90%86/%E6%96%87%E6%A1%A3)或者不需要新增文档 / This PR has updated usage guidelines and documentation or not need 
- [x] 通过必要的检查项 / All checks are green
